### PR TITLE
Append language code to generated subtitle filenames

### DIFF
--- a/app_env/filtering_vocab.py
+++ b/app_env/filtering_vocab.py
@@ -36,6 +36,9 @@ class Filtering(BaseClass):
         # Vocabs
         self.vocabs = Vocabs()
 
+        # хранит язык, определённый для последнего обработанного буфера
+        self.last_detected_language: Optional[str] = None
+
 
     def filtering_vocab(self, file_path: str)-> Optional[str]:
         """
@@ -268,6 +271,9 @@ class Filtering(BaseClass):
         """        
         name_method = self.get_current_method_name()
         
+        # обнуляем сохранённый язык перед новой попыткой определения
+        self.last_detected_language = None
+
         # определяем язык буфера титров для выбора языка словаря стоп-слов
         language = self.detection_lang(buffer_title)
         if not language:
@@ -277,8 +283,11 @@ class Filtering(BaseClass):
                     f'\n*language: [{language}]'
                     )
             print(msg)
-            self.logger.error(msg) 
+            self.logger.error(msg)
             return None
+
+        # сохраняем определённый язык, чтобы им могла воспользоваться логика сохранения файла
+        self.last_detected_language = language
         
         msg = (
                 f'\n[{self.cls_name}|{name_method}]'

--- a/stopwrdz.py
+++ b/stopwrdz.py
@@ -4,7 +4,7 @@
 # subtitle lines produced after punctuation removal.  This script is based off
 # the original TrustViking/Stopwrdz version.
 
-from os.path import split, join
+from os.path import split, join, splitext
 from typing import List, Optional, Dict, Union
 from io import BytesIO
 import re
@@ -285,6 +285,15 @@ class Start(BaseClass):
 
         # формируем уникальный путь для нового файла
         directory, filename = split(file_path)
+        language = self.filtering.last_detected_language
+        if language:
+            base_name, extension = splitext(nfile)
+            # если в конфигурации не указано расширение, используем исходное имя как есть
+            if extension:
+                nfile = f"{base_name}_{language}{extension}"
+            else:
+                nfile = f"{nfile}_{language}"
+
         new_full_path_title = join(directory, nfile)
         new_uniq_full_path_title = self.saving.get_unique_file_path(new_full_path_title)
         full_path_saving_title = self.saving.save_buffer_disk(


### PR DESCRIPTION
## Summary
- persist the language detected for subtitle processing so that it can be reused when saving the file
- update the generated subtitle filename to append the detected language code before the extension

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69121309db84832f9461d7c7b38d8df0)